### PR TITLE
Fix circleci badge link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-readme"
-version = "3.3.0"
+version = "3.2.0"
 edition = "2021"
 authors = ["Livio Ribeiro <livioribeiro@outlook.com>"]
 description = "A cargo subcommand to generate README.md content from doc comments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-readme"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 authors = ["Livio Ribeiro <livioribeiro@outlook.com>"]
 description = "A cargo subcommand to generate README.md content from doc comments"

--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -43,7 +43,7 @@ pub fn circle_ci(attrs: Attrs) -> String {
 
     format!(
         "[![Build Status](https://circleci.com/{service}/{repo}/tree/{branch}.svg?style=shield)]\
-         (https://circleci.com/{service}/{repo}/cargo-readme/tree/{branch})",
+         (https://circleci.com/{service}/{repo}/tree/{branch})",
         repo = repo,
         service = service,
         branch = percent_encode(branch)

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -2,7 +2,7 @@ use assert_cli::Assert;
 
 const EXPECTED: &str = r#"
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/cargo-readme/test?branch=master&svg=true)](https://ci.appveyor.com/project/cargo-readme/test/branch/master)
-[![Build Status](https://circleci.com/gh/cargo-readme/test/tree/master.svg?style=shield)](https://circleci.com/gh/cargo-readme/test/cargo-readme/tree/master)
+[![Build Status](https://circleci.com/gh/cargo-readme/test/tree/master.svg?style=shield)](https://circleci.com/gh/cargo-readme/test/tree/master)
 [![Build Status](https://gitlab.com/cargo-readme/test/badges/master/pipeline.svg)](https://gitlab.com/cargo-readme/test/commits/master)
 [![Build Status](https://travis-ci.org/cargo-readme/test.svg?branch=master)](https://travis-ci.org/cargo-readme/test)
 [![Coverage Status](https://codecov.io/gh/cargo-readme/test/branch/master/graph/badge.svg)](https://codecov.io/gh/cargo-readme/test)


### PR DESCRIPTION
The badge URL for circle-ci had `/cargo-readme/` on it, and
predictably, the links 404. This change fixes that and points them to the
correct URL.
