### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: cargo-readme
+  name: cargo-readme
+  description: Generate README.md from docstrings
+  entry: cargo-readme readme
+  language: rust
+  files: (README\.tpl)|(\.(md)|(rs))$
+  args: [--output=README.md]
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -145,6 +145,31 @@ License: MY_LICENSE
 By default, `README.tpl` will be used as the template, but you can override it using the
 `--template` to choose a different template or `--no-template` to disable it.
 
+## Usage with [pre-commit](https://pre-commit.com)
+
+```yaml
+repos:
+  - repo: https://github.com/webern/cargo-readme
+    rev: vX.Y.Z
+    hooks:
+      - id: cargo-readme
+```
+
+If your package resides in a subdirectory:
+
+```yaml
+repos:
+  - repo: https://github.com/webern/cargo-readme
+    rev: vX.Y.Z
+    hooks:
+      - id: cargo-readme
+        args: [
+          --project-root=my-subdirectory,
+          --output=../README.md,
+          --template=../README.tpl,
+        ]
+```
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
Adds a convenient [pre-commit](https://pre-commit.com) hook to automatically create/update the README before commits.

To debug it, you can follow the next instructions:

1. Install Python
2. Install pre-commit with `pip install pre-commit`
3. Add a file `.pre-commit-config.yaml` to your repository with the next content:
   ```yaml
   - repo: https://github.com/mondeja/cargo-readme
     rev: add-pre-commit-hook
     hooks:
       - id: cargo-readme
   ```
4. Run `pre-commit run -a cargo-readme`
5. Change the content of `src/lib.rs`, `README.md` or `README.tpl` and run again. Check that the content is updated.

Note that in this reproduction I'm using my fork and that will show a warning but users would use a `vX.Y.Z` tag, hence that is reflected in the documentation. Pre-commit users are accustomed to using that pattern.