### PR TITLE
Fix compilation warning with recent rust

### DIFF
--- a/src/config/badges.rs
+++ b/src/config/badges.rs
@@ -178,7 +178,7 @@ pub fn maintenance(attrs: Attrs) -> String {
     )
 }
 
-fn percent_encode(input: &str) -> pe::PercentEncode {
+fn percent_encode(input: &str) -> pe::PercentEncode<'_> {
     pe::utf8_percent_encode(input, pe::NON_ALPHANUMERIC)
 }
 


### PR DESCRIPTION
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/config/badges.rs:181:26
    |
181 | fn percent_encode(input: &str) -> pe::PercentEncode {
    |                          ^^^^     ^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                          |
    |                          the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
181 | fn percent_encode(input: &str) -> pe::PercentEncode<'_> {
    |                                                    ++++

warning: `cargo-readme` (lib) generated 1 warning (run `cargo fix --lib -p cargo-readme` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
```