### PR TITLE
Switch from assert_cli to assert_cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,39 +62,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cli"
-version = "0.6.3"
+name = "assert_cmd"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29ab7c0ed62970beb0534d637a8688842506d0ff9157de83286dacd065c8149"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
- "colored",
- "difference",
- "environment",
- "failure",
- "failure_derive",
- "serde_json",
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.75"
+name = "bstr"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets",
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
 name = "cargo-readme"
 version = "3.3.1"
 dependencies = [
- "assert_cli",
+ "assert_cmd",
  "clap",
  "lazy_static",
  "percent-encoding",
@@ -117,12 +100,6 @@ dependencies = [
  "serde",
  "toml",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
@@ -155,7 +132,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -171,61 +148,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "colored"
-version = "1.9.4"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f741c91823341bebf717d4c71bda820630ce065443b58bd1b7451af008355"
-dependencies = [
- "is-terminal",
- "lazy_static",
- "winapi",
-]
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "difference"
-version = "2.0.0"
+name = "doc-comment"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "environment"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
@@ -240,12 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,27 +188,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -297,24 +212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +222,33 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -374,18 +298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,19 +314,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.140"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
+ "syn",
 ]
 
 [[package]]
@@ -434,17 +334,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
@@ -455,16 +344,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
+name = "termtree"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "toml"
@@ -514,38 +397,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "wait-timeout"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "libc",
 ]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ percent-encoding = "2"
 lazy_static = "1"
 
 [dev-dependencies]
-assert_cli = "0.6"
+assert_cmd = "2.0.17"
 
 [badges]
 github = { repository = "webern/cargo-readme" }

--- a/tests/alternate-input.rs
+++ b/tests/alternate-input.rs
@@ -1,4 +1,4 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
 #[test]
 fn alternate_input_empty_docs() {
@@ -12,13 +12,12 @@ fn alternate_input_empty_docs() {
         "src/no_docs.rs",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is("# readme-test\n\nLicense: MIT")
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout("# readme-test\n\nLicense: MIT\n");
 }
 
 #[test]
@@ -33,21 +32,19 @@ fn alternate_input_single_line() {
         "src/single_line.rs",
     ];
 
-    let expected = r#"
-# readme-test
+    let expected = r#"# readme-test
 
 Test crate for cargo-readme
 
 License: MIT
 "#;
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(expected)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(expected);
 }
 
 #[test]
@@ -62,8 +59,7 @@ fn alternate_input_a_little_bit_longer() {
         "src/other.rs",
     ];
 
-    let expected = r#"
-# readme-test
+    let expected = r#"# readme-test
 
 Test crate for cargo-readme
 
@@ -72,11 +68,10 @@ Test crate for cargo-readme
 License: MIT
 "#;
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(expected)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(expected);
 }

--- a/tests/alternate-template.rs
+++ b/tests/alternate-template.rs
@@ -1,7 +1,6 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
-const EXPECTED: &str = r#"
-# readme-test
+const EXPECTED: &str = r#"# readme-test
 
 Other readme template.
 
@@ -54,11 +53,10 @@ fn alternate_template() {
         "NOTITLE.tpl",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(EXPECTED);
 }

--- a/tests/append-license.rs
+++ b/tests/append-license.rs
@@ -1,7 +1,6 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
-const EXPECTED: &str = r#"
-# readme-test
+const EXPECTED: &str = r#"# readme-test
 
 Test crate for cargo-readme
 
@@ -52,15 +51,14 @@ fn append_license() {
         "--no-badges",
     ];
 
-    let expected = format!("{}\n\n{}", EXPECTED.trim(), "License: MIT");
+    let expected = format!("{}\n\n{}\n", EXPECTED.trim(), "License: MIT");
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(&*expected)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(expected);
 }
 
 #[test]
@@ -74,11 +72,10 @@ fn no_append_license() {
         "--no-license",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(EXPECTED);
 }

--- a/tests/badges.rs
+++ b/tests/badges.rs
@@ -1,7 +1,6 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
-const EXPECTED: &str = r#"
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/cargo-readme/test?branch=master&svg=true)](https://ci.appveyor.com/project/cargo-readme/test/branch/master)
+const EXPECTED: &str = r#"[![Build Status](https://ci.appveyor.com/api/projects/status/github/cargo-readme/test?branch=master&svg=true)](https://ci.appveyor.com/project/cargo-readme/test/branch/master)
 [![Build Status](https://circleci.com/gh/cargo-readme/test/tree/master.svg?style=shield)](https://circleci.com/gh/cargo-readme/test/tree/master)
 [![Build Status](https://gitlab.com/cargo-readme/test/badges/master/pipeline.svg)](https://gitlab.com/cargo-readme/test/commits/master)
 [![Build Status](https://travis-ci.org/cargo-readme/test.svg?branch=master)](https://travis-ci.org/cargo-readme/test)
@@ -21,11 +20,10 @@ License: MIT
 fn badges() {
     let args = ["readme", "--project-root", "tests/badges"];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(EXPECTED);
 }

--- a/tests/default-behavior.rs
+++ b/tests/default-behavior.rs
@@ -1,7 +1,6 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
-const EXPECTED: &str = r#"
-[![Build Status](https://travis-ci.org/livioribeiro/cargo-readme.svg?branch=master)](https://travis-ci.org/livioribeiro/cargo-readme)
+const EXPECTED: &str = r#"[![Build Status](https://travis-ci.org/livioribeiro/cargo-readme.svg?branch=master)](https://travis-ci.org/livioribeiro/cargo-readme)
 
 # readme-test
 
@@ -50,11 +49,10 @@ if condition {
 fn default_behavior() {
     let args = ["readme", "--project-root", "tests/test-project"];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(EXPECTED);
 }

--- a/tests/entrypoint-resolution.rs
+++ b/tests/entrypoint-resolution.rs
@@ -1,4 +1,4 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
 #[test]
 fn entrypoint_resolution_main() {
@@ -10,13 +10,12 @@ fn entrypoint_resolution_main() {
         "--no-license",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is("main")
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout("main\n");
 }
 
 #[test]
@@ -29,13 +28,12 @@ fn entrypoint_resolution_lib() {
         "--no-license",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is("lib")
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout("lib\n");
 }
 
 #[test]
@@ -48,13 +46,12 @@ fn entrypoint_resolution_cargo_lib() {
         "--no-license",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is("cargo lib")
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout("cargo lib\n");
 }
 
 #[test]
@@ -67,11 +64,10 @@ fn entrypoint_resolution_cargo_bin() {
         "--no-license",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is("cargo bin")
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout("cargo bin\n");
 }

--- a/tests/multiline-doc.rs
+++ b/tests/multiline-doc.rs
@@ -1,7 +1,6 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
-const EXPECTED: &str = r#"
-[![Build Status](https://travis-ci.org/livioribeiro/cargo-readme.svg?branch=master)](https://travis-ci.org/livioribeiro/cargo-readme)
+const EXPECTED: &str = r#"[![Build Status](https://travis-ci.org/livioribeiro/cargo-readme.svg?branch=master)](https://travis-ci.org/livioribeiro/cargo-readme)
 
 # readme-test
 
@@ -56,11 +55,10 @@ fn multiline_doc() {
         "src/multiline.rs",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(EXPECTED);
 }

--- a/tests/multiple-bin-fail.rs
+++ b/tests/multiple-bin-fail.rs
@@ -1,16 +1,16 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
-const EXPECTED: &str = "Error: Multiple binaries found, choose one: [src/entry1.rs, src/entry2.rs]";
+const EXPECTED: &str =
+    "Error: Multiple binaries found, choose one: [src/entry1.rs, src/entry2.rs]\n";
 
 #[test]
 fn multiple_bin_fail() {
     let args = ["readme", "--project-root", "tests/multiple-bin-fail"];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .fails()
-        .and()
-        .stderr()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .failure()
+        .stderr(EXPECTED);
 }

--- a/tests/no-entrypoint-fail.rs
+++ b/tests/no-entrypoint-fail.rs
@@ -1,16 +1,15 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
-const EXPECTED: &str = "Error: No entrypoint found";
+const EXPECTED: &str = "Error: No entrypoint found\n";
 
 #[test]
 fn no_entrypoint_fail() {
     let args = ["readme", "--project-root", "tests/no-entrypoint-fail"];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .fails()
-        .and()
-        .stderr()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .failure()
+        .stderr(EXPECTED);
 }

--- a/tests/no-template.rs
+++ b/tests/no-template.rs
@@ -1,7 +1,6 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
-const EXPECTED: &str = r#"
-# readme-test
+const EXPECTED: &str = r#"# readme-test
 
 Test crate for cargo-readme
 
@@ -54,11 +53,10 @@ fn no_template() {
         "--no-badges",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(EXPECTED);
 }

--- a/tests/project-with-version.rs
+++ b/tests/project-with-version.rs
@@ -1,10 +1,11 @@
-use assert_cli::Assert;
+use assert_cmd::Command;
 
 const EXPECTED: &str = "# project-with-version
 
 Current version: 0.1.0
 
-A test project with a version provided.";
+A test project with a version provided.
+";
 
 #[test]
 fn template_with_version() {
@@ -16,11 +17,10 @@ fn template_with_version() {
         "README.tpl",
     ];
 
-    Assert::main_binary()
-        .with_args(&args)
-        .succeeds()
-        .and()
-        .stdout()
-        .is(EXPECTED)
-        .unwrap();
+    Command::cargo_bin("cargo-readme")
+        .unwrap()
+        .args(&args)
+        .assert()
+        .success()
+        .stdout(EXPECTED);
 }


### PR DESCRIPTION
Test fail with recent rust:

```
running 1 test
test multiple_bin_fail ... FAILED

failures:

---- multiple_bin_fail stdout ----

thread 'multiple_bin_fail' (2462685) panicked at /home/marakasov/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/assert_cli-0.6.3/src/assert.rs:441:13:
Assertion failed for `cargo run --quiet -- readme --project-root tests/multiple-bin-fail`
with: Unexpected stderr

with: Didn't match.
diff=
 ``+warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/config/badges.rs:181:26
    |
181 | fn percent_encode(input: &str) -> pe::PercentEncode {
    |                          ^^^^     ^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                          |
    |                          the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
181 | fn percent_encode(input: &str) -> pe::PercentEncode<'_> {
    |                                                    ++++

 Error: Multiple binaries found, choose one: [src/entry1.rs, src/entry2.rs]
 ```
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    multiple_bin_fail
```

This is caused by two problems
- There is compilation warning (addressed in #114)
- `assert_cli` calls `cargo run` instead of calling a real crate binary, which leads to cargo stderr (which contains a warning) prepended to command output. Since `assert_cli` is deprecated, switch to `assert_cmd` everywhere. Because unlike `assert_cli` it does not ignore leading/trailing whitespace in expected stderr/stdout contents, leading newlines had to be removed in inline expected data. If you find it undesirable, it can be fixed by adding `trim_start` or switching to `indoc` (more convenient multiline string literals) or `insta` (snapshot tests - keeps expected data in separate files and assists in updating them).